### PR TITLE
added some delays

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -37,6 +38,8 @@ carrying the name as a prefix to easily identify.
 		for _, vmName := range vmNames {
 			wg.Add(1)
 			go spawnLimaVM(vmName, &wg, errCh)
+			// @TODO - Serialize properly
+			time.Sleep(10 * time.Second)
 		}
 
 		// Wait for all goroutines to finish

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	lima "github.com/ranjandas/shikari/app"
 	"github.com/spf13/cobra"
@@ -37,6 +38,8 @@ $ shikari start -n murphy`,
 		for _, vmName := range stoppedInstances {
 			wg.Add(1)
 			go lima.StartLimaVM(vmName.Name, &wg, errCh)
+			// @TODO - Serialize properly
+			time.Sleep(10 * time.Second)
 		}
 
 		// Wait for all goroutines to finish

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/ranjandas/shikari
 
-go 1.22.3
+// X.Y format only supported under vscode
+go 1.22 
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect


### PR DESCRIPTION
Added delays (with TODO to serialize better) and updated the go version that was working in VS Code.
Also validated that this is working for alpine + fedora templates.