### PR TITLE
Allow local templates for VM creation

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -94,7 +94,13 @@ func init() {
 func spawnLimaVM(vmName string, modeEnv string, userEnv string, wg *sync.WaitGroup, errCh chan<- error) {
 	defer wg.Done()
 
-	tmpl := fmt.Sprintf("template://%s", template)
+	var tmpl string
+
+	if strings.HasSuffix(strings.ToLower(template), ".yml") || strings.HasSuffix(strings.ToLower(template), ".yaml") {
+		tmpl = template
+	} else {
+		tmpl = fmt.Sprintf("template://%s", template)
+	}
 
 	//--set '. |= .env.mode="server", .env.cluster="murphy"'
 	yqExpression := fmt.Sprintf(`.env.CLUSTER="%s" | .env.MODE="%s"`, name, modeEnv)


### PR DESCRIPTION
This PR allows the template files outside the lima standard template path to be passed into lima when the files have extension of `.yml` or `.yaml`.