### PR TITLE
Introduced shikari list command

### DIFF
--- a/app/lima.go
+++ b/app/lima.go
@@ -11,11 +11,6 @@ import (
 	"sync"
 )
 
-type LimaVM struct {
-	Name   string `json:"name"`
-	Status string `json:"status"`
-}
-
 func ListInstances() []LimaVM {
 	cmd := exec.Command("limactl", "list", "--json")
 

--- a/app/types.go
+++ b/app/types.go
@@ -1,0 +1,9 @@
+package lima
+
+type LimaVM struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Memory uint64 `json:"memory"`
+	Disk   uint64 `json:"disk"`
+	Cpus   int    `json:"cpus"`
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,86 @@
+/*
+Copyright © 2024 Ranjandas Athiyanathum Poyil thejranjan@gmail.com
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"text/tabwriter"
+
+	lima "github.com/ranjandas/shikari/app"
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List VMs belonging to clusters",
+	Long:  `List VMs belonging to clusters`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		name, _ := cmd.Flags().GetString("name")
+		listInstances(name)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+
+	listCmd.Flags().StringP("name", "n", "", "name of the  cluster")
+	listCmd.Flags().BoolVarP(&header, "no-header", "", false, "skip the header from list output")
+}
+
+var header bool
+
+func listInstances(clusterName string) {
+	vms := lima.ListInstances()
+
+	w := tabwriter.NewWriter(os.Stdout, 5, 3, 7, byte(' '), 0)
+
+	if !header {
+		fmt.Fprintln(w, "CLUSTER\tVM NAME\tSATUS\tDISK(GB)\tMEMORY(GB)\tCPUS")
+	}
+
+	for _, vm := range vms {
+		if isShikariVM(vm.Name) {
+
+			if len(name) > 0 {
+				if !strings.HasPrefix(vm.Name, clusterName) {
+					continue //skip printing the
+				}
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%d\n", getClusterNameFromInstanceName(vm.Name), vm.Name, vm.Status, bytesToGiB(vm.Disk), bytesToGiB(vm.Memory), vm.Cpus)
+		}
+	}
+	w.Flush()
+}
+
+func getClusterNameFromInstanceName(name string) string {
+	clusterName := strings.Split(name, "-")
+
+	return clusterName[0]
+}
+
+func isShikariVM(name string) bool {
+	pattern := `^([a-zA-Z]+)-(srv|cli)-(\d+)$`
+
+	regex, err := regexp.Compile(pattern)
+
+	if err != nil {
+		fmt.Println("Error compiling regex:", err)
+	}
+
+	if match := regex.MatchString(name); match {
+		return true
+	}
+
+	return false
+}
+
+func bytesToGiB(bytes uint64) uint64 {
+	const GiB = 1 << (10 * 3)
+	return bytes / GiB
+}


### PR DESCRIPTION
Introduced the `shikari list` command, which would print the list of VMs spawned using Shikari. The detection is based on a simple regex matching of the name in the form of `xxx-yyy-zzz` (where `xxx` can be any word without special characters, `yyy` can be either `cli` or `srv` and `zzz` any number.