### PR TITLE
Refactor Shikari Injected Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,12 @@ murphy-srv-03    Running    127.0.0.1:62279    qemu      4       4GiB      100Gi
 
 When spinning up the VM's, Shikari injects a few environment variables into each VM's, which would give some additional context to the provisioning scripts that would include:
 
-* What kind of node the script is running on (injected as `MODE` env variable)
-* Name of the cluster (injected as `CLUSTER` env variable)
-* Count of Number of Servers (injected as `BOOTSTRAP_EXPECT` env variable)
+* What kind of node the script is running on (injected as `SHIKARI_VM_MODE` env variable)
+* Name of the cluster (injected as `SHIKARI_CLUSTER_NAME` env variable)
+* Count of Number of Servers (injected as `SHIKARI_SERVER_COUNT` env variable)
+* Count of Number of Clients (injected as `SHIKARI_CLIENT_COUNT` env variable)
+
+> NOTE: The variables are prefixed with `SHIKARI_` from `v0.3.0`. Please refer to the specific version doc to find the right variables.
 
 > NOTE: Please open GH [issues](https://github.com/Ranjandas/shikari/issues) if you would like to have additional variables injected.
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -113,8 +113,12 @@ func spawnLimaVM(vmName string, modeEnv string, userEnv string, wg *sync.WaitGro
 		tmpl = fmt.Sprintf("template://%s", template)
 	}
 
-	//--set '. |= .env.mode="server", .env.cluster="murphy"'
-	yqExpression := fmt.Sprintf(`.env.CLUSTER="%s" | .env.MODE="%s" | .env.BOOTSTRAP_EXPECT="%d"`, name, modeEnv, servers)
+	// example: --set '. |= .env.SHIKARI_VM_MODE="server", .env.SHIKARI_CLUSTER_NAME="murphy"'
+	yqExpression := fmt.Sprintf(`.env.SHIKARI_CLUSTER_NAME="%s" | .env.SHIKARI_VM_MODE="%s"`, name, modeEnv)
+
+	// append server and client count variables
+	countEnvVars := fmt.Sprintf(`.env.SHIKARI_SERVER_COUNT="%d" | .env.SHIKARI_CLIENT_COUNT="%d"`, servers, clients)
+	yqExpression = fmt.Sprintf("%s |  %s", yqExpression, countEnvVars)
 
 	// append user defined environment variable
 	if userEnv != "" {


### PR DESCRIPTION
* All the Shikari-generated variables have `SHIKARI_` prefix
* Removed `BOOTSTRAP_EXPECT` variable
* Added `SHIKARI_SERVER_COUNT` and `SHIKARI_CLIENT_COUNT` variables
* Updated the Documentation to reflect the variable changes.


```
limactl shell secure-srv-01 env | grep SHIKARI
SHIKARI_CLUSTER_NAME=secure
SHIKARI_VM_MODE=server
SHIKARI_CLIENT_COUNT=0
SHIKARI_SERVER_COUNT=1
```


Fixes: #29, #30 