### PR TITLE
Only have Server agents for Env Variables

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -72,7 +72,8 @@ func printClientConfigEnvs(config ClientConfigOpts) {
 }
 
 func getRandomServer(config ClientConfigOpts) string {
-	instances := lima.GetInstancesByPrefix(config.Name)
+	// always get the instances of type server "-srv"
+	instances := lima.GetInstancesByPrefix(fmt.Sprintf("%s-srv", config.Name))
 	runningInstances := lima.GetInstancesByStatus(instances, "running")
 
 	if !(len(runningInstances) > 0) {


### PR DESCRIPTION
We should only set the server agent IP for `*_ADDR` environment variables. We recently found that `consul members -partition <>` command was failing and it was due to the query hitting a client that belonged to non-default partition.