### PR TITLE
Add scenario name to the list output

### DIFF
--- a/app/lima/lima.go
+++ b/app/lima/lima.go
@@ -156,3 +156,18 @@ func SpawnLimaVM(vmName string, tmpl string, yqExpression string, wg *sync.WaitG
 
 	fmt.Printf("Lima VM %s spawned successfully.\n", vmName)
 }
+
+func (vm LimaVM) GetScenarioNameFromEnv() string {
+
+	scenario_name := ""
+
+	if len(vm.Config.Env) == 0 {
+		scenario_name = ""
+	}
+
+	if env, ok := vm.Config.Env["SHIKARI_SCENARIO_NAME"]; ok {
+		scenario_name = env
+	}
+
+	return scenario_name
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -40,7 +40,7 @@ func listInstances(clusterName string) {
 	w := tabwriter.NewWriter(os.Stdout, 5, 3, 7, byte(' '), 0)
 
 	if !header {
-		fmt.Fprintln(w, "CLUSTER\tVM NAME\tSATUS\tDISK(GB)\tMEMORY(GB)\tCPUS\tIMAGE")
+		fmt.Fprintln(w, "CLUSTER\tVM NAME\tSTATUS\tSCENARIO\tDISK(GB)\tMEMORY(GB)\tCPUS\tIMAGE")
 	}
 
 	for _, vm := range vms {
@@ -51,7 +51,7 @@ func listInstances(clusterName string) {
 					continue //skip printing the
 				}
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%d\t%s\n", getClusterNameFromInstanceName(vm.Name), vm.Name, vm.Status, bytesToGiB(vm.Disk), bytesToGiB(vm.Memory), vm.Cpus, getImageLocation(vm.Config.Images))
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\n", getClusterNameFromInstanceName(vm.Name), vm.Name, vm.Status, vm.GetScenarioNameFromEnv(), bytesToGiB(vm.Disk), bytesToGiB(vm.Memory), vm.Cpus, getImageLocation(vm.Config.Images))
 		}
 	}
 	w.Flush()


### PR DESCRIPTION
Add the scenario field in the `list` output to identify which scenario the cluster was launched with.

```
go run . list
CLUSTER       VM NAME             STATUS        SCENARIO                       DISK(GB)       MEMORY(GB)       CPUS       IMAGE
murphy        murphy-cli-01       Running       nomad-consul-secure            100            4                4          /Users/ranjan/.shikari/artifacts/c-1.18-n-1.7-v-1.17/hashibox.qcow2
murphy        murphy-cli-02       Running       nomad-consul-secure            100            4                4          /Users/ranjan/.shikari/artifacts/c-1.18-n-1.7-v-1.17/hashibox.qcow2
murphy        murphy-cli-03       Running       nomad-consul-secure            100            4                4          /Users/ranjan/.shikari/artifacts/c-1.18-n-1.7-v-1.17/hashibox.qcow2
murphy        murphy-srv-01       Running       nomad-consul-secure            100            4                4          /Users/ranjan/.shikari/artifacts/c-1.18-n-1.7-v-1.17/hashibox.qcow2
murphy        murphy-srv-02       Running       nomad-consul-secure            100            4                4          /Users/ranjan/.shikari/artifacts/c-1.18-n-1.7-v-1.17/hashibox.qcow2
murphy        murphy-srv-03       Running       nomad-consul-secure            100            4                4          /Users/ranjan/.shikari/artifacts/c-1.18-n-1.7-v-1.17/hashibox.qcow2
vault         vault-srv-01        Running       vault-integrated-storage       100            4                4          /Users/ranjan/workspace/github/shikari-scenarios/packer/.artifacts/c-1.18-n-1.7-v-1.17/c-1.18-n-1.7-v-1.17.qcow2
vault         vault-srv-02        Running       vault-integrated-storage       100            4                4          /Users/ranjan/workspace/github/shikari-scenarios/packer/.artifacts/c-1.18-n-1.7-v-1.17/c-1.18-n-1.7-v-1.17.qcow2
vault         vault-srv-03        Running       vault-integrated-storage       100            4                4          /Users/ranjan/workspace/github/shikari-scenarios/packer/.artifacts/c-1.18-n-1.7-v-1.17/c-1.18-n-1.7-v-1.17.qcow2
```