### PR TITLE
Add K3S to env subcommand to use with K3S scenarios

### DIFF
--- a/app/lima/lima.go
+++ b/app/lima/lima.go
@@ -33,6 +33,26 @@ func ListInstances() []LimaVM {
 	return vms
 }
 
+func GetInstance(name string) LimaVM {
+
+	var vm LimaVM
+
+	vms := ListInstances()
+
+	if len(vms) == 0 {
+		return vm
+	}
+
+	for _, v := range vms {
+		if v.Name == name {
+			vm = v
+			break
+		}
+	}
+
+	return vm
+}
+
 func GetInstancesByPrefix(name string) []LimaVM {
 	var filteredInstances []LimaVM
 
@@ -170,4 +190,37 @@ func (vm LimaVM) GetScenarioNameFromEnv() string {
 	}
 
 	return scenario_name
+}
+
+func (vm LimaVM) GetVMDir() string {
+	return vm.Dir
+}
+
+func (vm LimaVM) GetIPAddress() string {
+
+	command := "ip -j addr show dev lima0"
+	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("limactl shell %s %s", vm.Name, command))
+
+	output, err := cmd.Output()
+
+	if err != nil {
+		fmt.Println("Error:", err)
+		return ""
+	}
+
+	var interfaces []Interface
+	err = json.Unmarshal([]byte(output), &interfaces)
+	if err != nil {
+		log.Fatalf("Error unmarshalling JSON: %v", err)
+	}
+
+	// Extract the local address where family is "inet"
+	for _, iface := range interfaces {
+		for _, addrInfo := range iface.AddrInfo {
+			if addrInfo.Family == "inet" {
+				return addrInfo.Local
+			}
+		}
+	}
+	return ""
 }

--- a/app/lima/types.go
+++ b/app/lima/types.go
@@ -13,8 +13,20 @@ type Image struct {
 type LimaVM struct {
 	Name   string `json:"name"`
 	Status string `json:"status"`
+	Dir    string `json:"dir"`
 	Memory uint64 `json:"memory"`
 	Disk   uint64 `json:"disk"`
 	Cpus   int    `json:"cpus"`
 	Config Config `json:"config,omitempty"`
+}
+
+type AddrInfo struct {
+	Family string `json:"family"`
+	Local  string `json:"local"`
+}
+
+type Interface struct {
+	IfIndex  int        `json:"ifindex"`
+	IfName   string     `json:"ifname"`
+	AddrInfo []AddrInfo `json:"addr_info"`
 }


### PR DESCRIPTION
Add K3S to the `env` subcommand to use with K3S scenarios. When the `env` subcommand is invoked with the `k3s` product, it does the following:

* Copies the KUBECONFIG file (`/etc/rancher/k3s/k3s.yaml`) from the first Server VM of the cluster to the instance directory
* Exports KUBECONFIG environment variable pointing to the right path on the host.

```
shikari feature/k3s-env*​ ≡
❯ ./shikari list
CLUSTER       VM NAME          STATUS        SCENARIO            DISK(GB)       MEMORY(GB)       CPUS       IMAGE
k3s           k3s-cli-01       Running       k3s-multinode       100            4                4          https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img
k3s           k3s-srv-01       Running       k3s-multinode       100            4                4          https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img
k3s           k3s-srv-02       Running       k3s-multinode       100            4                4          https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img
k3s           k3s-srv-03       Running       k3s-multinode       100            4                4          https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img

shikari feature/k3s-env*​ ≡
❯ ./shikari env -n k3s k3s
export KUBECONFIG=/Users/ranjan/.lima/k3s-srv-01/k3s.yaml

shikari feature/k3s-env*​ ≡
❯ eval $(./shikari env -n k3s k3s)

shikari feature/k3s-env*​ ≡
❯ k get nodes -o wide
NAME              STATUS   ROLES                       AGE   VERSION        INTERNAL-IP       EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION     CONTAINER-RUNTIME
lima-k3s-cli-01   Ready    <none>                      11m   v1.29.6+k3s1   192.168.105.101   <none>        Ubuntu 24.04 LTS   6.8.0-31-generic   containerd://1.7.17-k3s1
lima-k3s-srv-01   Ready    control-plane,etcd,master   11m   v1.29.6+k3s1   192.168.105.99    <none>        Ubuntu 24.04 LTS   6.8.0-31-generic   containerd://1.7.17-k3s1
lima-k3s-srv-02   Ready    control-plane,etcd,master   11m   v1.29.6+k3s1   192.168.105.100   <none>        Ubuntu 24.04 LTS   6.8.0-31-generic   containerd://1.7.17-k3s1
lima-k3s-srv-03   Ready    control-plane,etcd,master   11m   v1.29.6+k3s1   192.168.105.103   <none>        Ubuntu 24.04 LTS   6.8.0-31-generic   containerd://1.7.17-k3s1
```

