### PR TITLE
Add `SHIKARI_LAUNCH_MODE` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ When spinning up the VM's, Shikari injects a few environment variables into each
 * Name of the cluster (injected as `SHIKARI_CLUSTER_NAME` env variable)
 * Count of Number of Servers (injected as `SHIKARI_SERVER_COUNT` env variable)
 * Count of Number of Clients (injected as `SHIKARI_CLIENT_COUNT` env variable)
+* Launch mode of VMs (`CREATE` or `SCALE`) (injected as `SHIKARI_LAUNCH_MODE` env variable)
 
 > NOTE: The variables are prefixed with `SHIKARI_` from `v0.3.0`. Please refer to the specific version doc to find the right variables.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ When spinning up the VM's, Shikari injects a few environment variables into each
 * Name of the cluster (injected as `SHIKARI_CLUSTER_NAME` env variable)
 * Count of Number of Servers (injected as `SHIKARI_SERVER_COUNT` env variable)
 * Count of Number of Clients (injected as `SHIKARI_CLIENT_COUNT` env variable)
-* Launch mode of VMs (`CREATE` or `SCALE`) (injected as `SHIKARI_LAUNCH_MODE` env variable)
+* Launch mode of VMs (`create` or `scale`) (injected as `SHIKARI_LAUNCH_MODE` env variable)
 
 > NOTE: The variables are prefixed with `SHIKARI_` from `v0.3.0`. Please refer to the specific version doc to find the right variables.
 

--- a/app/shikari/shikari.go
+++ b/app/shikari/shikari.go
@@ -264,8 +264,8 @@ func (c ShikariCluster) validateName() bool {
 
 func launchMode(scale bool) string {
 	if scale {
-		return "SCALE"
+		return "scale"
 	}
 
-	return "CREATE"
+	return "create"
 }

--- a/app/shikari/shikari.go
+++ b/app/shikari/shikari.go
@@ -114,7 +114,8 @@ func (c ShikariCluster) CreateCluster(scale bool) {
 
 		// append server and client count variables
 		countEnvVars := fmt.Sprintf(`.env.SHIKARI_SERVER_COUNT="%d" | .env.SHIKARI_CLIENT_COUNT="%d"`, c.NumServers, c.NumClients)
-		yqExpression = fmt.Sprintf("%s |  %s", yqExpression, countEnvVars)
+		launchModeEnvVar := fmt.Sprintf(`.env.SHIKARI_LAUNCH_MODE="%s"`, launchMode(scale))
+		yqExpression = fmt.Sprintf("%s |  %s | %s", yqExpression, countEnvVars, launchModeEnvVar)
 
 		// append user defined environment variable
 		if userDefinedEnvs != "" {
@@ -259,4 +260,12 @@ func (c ShikariCluster) validateName() bool {
 	regex, _ := regexp.Compile(pattern)
 
 	return regex.MatchString(c.Name)
+}
+
+func launchMode(scale bool) string {
+	if scale {
+		return "SCALE"
+	}
+
+	return "CREATE"
 }


### PR DESCRIPTION
This PR adds a new environment variable named SHIKARI_LAUNCH_MODE with the values "scale" or "create".

This is useful when the provisioning scripts have to know whether its being executed as part of a create or scale action.