### PR TITLE
Add shell subcommand

### DIFF
--- a/app/lima/lima.go
+++ b/app/lima/lima.go
@@ -177,6 +177,27 @@ func SpawnLimaVM(vmName string, tmpl string, yqExpression string, wg *sync.WaitG
 	fmt.Printf("Lima VM %s spawned successfully.\n", vmName)
 }
 
+func ShellLimaVM(vmName string) {
+
+	limaCmd := fmt.Sprintf("limactl shell '%s'", vmName)
+	cmd := exec.Command("/bin/sh", "-c", limaCmd)
+
+	// Set the input to os.Stdin, output to os.Stdout and os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Run the command
+	if err := cmd.Start(); err != nil {
+		log.Fatalf("Failed to get a shell inside %s: %v", vmName, err)
+	}
+
+	// Wait for the command to finish and check for errors
+	if err := cmd.Wait(); err != nil {
+		log.Fatalf("Command finished with error: %v", err)
+	}
+}
+
 func (vm LimaVM) GetScenarioNameFromEnv() string {
 
 	scenario_name := ""

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1,0 +1,42 @@
+/*
+Copyright © 2024 Ranjandas Athiyanathum Poyil thejranjan@gmail.com
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ranjandas/shikari/app/lima"
+	"github.com/spf13/cobra"
+)
+
+// shellCmd represents the shell command
+var shellCmd = &cobra.Command{
+	Use:   "shell",
+	Short: "Get a shell inside the VM",
+	Long:  `Get a shell inside the VM`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !(len(args) > 0) {
+			fmt.Println("No Instance name passed")
+			return
+		}
+
+		vm := lima.GetInstance(args[0])
+		// return if no instance with the name was found
+		if vm.Name == "" || vm.Status != "Running" {
+			fmt.Printf("No running instance found with the name \"%s\"\n", args[0])
+			return
+		}
+
+		lima.ShellLimaVM(vm.Name)
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(shellCmd)
+
+	usageString := "Usage:\n shikari shell <vm-name> [flags]\n\nFlags:\n -h, --help help for shell\n"
+
+	shellCmd.SetUsageTemplate(usageString)
+}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -36,7 +36,7 @@ var shellCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(shellCmd)
 
-	usageString := "Usage:\n shikari shell <vm-name> [flags]\n\nFlags:\n -h, --help help for shell\n"
+	usageString := "Usage:\n shikari shell <vm-name>\n\nFlags:\n -h, --help help for shell\n"
 
 	shellCmd.SetUsageTemplate(usageString)
 }


### PR DESCRIPTION
This PR adds `shell` subcommand which allows to get a shell inside the VM.

This is a wrapper on limactl shell and with this feature we don't have to use limactl for interacting with the cluster.

```
# Running VM
❯ ./shikari shell k3s-srv-01
ranjan@lima-k3s-srv-01:~$ cat /etc/os-release 
PRETTY_NAME="Ubuntu 24.04 LTS"
NAME="Ubuntu"
...
...
ranjan@lima-k3s-srv-01:~$ exit
logout


# Non existent VM
❯ ./shikari shell non-existent-vm
No running instance found with the name "non-existent-vm"


# Stopped VM
❯ limactl ls | grep Stopped
fedora        Stopped    127.0.0.1:0        vz        4       4GiB      100GiB    ~/.lima/fedora

❯ ./shikari shell fedora         
No running instance found with the name "fedora"
```