### PR TITLE
Fetch IP only for running instances

### DIFF
--- a/app/lima/lima.go
+++ b/app/lima/lima.go
@@ -219,6 +219,10 @@ func (vm LimaVM) GetVMDir() string {
 
 func (vm LimaVM) GetIPAddress() string {
 
+	if vm.Status != "Running" {
+		return ""
+	}
+
 	command := "ip -j addr show dev lima0"
 	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("limactl shell %s %s", vm.Name, command))
 


### PR DESCRIPTION
To avoid errors, as shown below for stopped VM instances.

```
$ shikari list
Error: exit status 1
Error: exit status 1
CLUSTER    VM NAME          IP(lima0)    STATUS     SCENARIO                   DISK(GB)    MEMORY(GB)    CPUS    IMAGE
murphy     murphy-cli-01                 Stopped    nomad-consul-quickstart    100         4             4       /Users/ranjan/.shikari/c-1.19-n-1.8-v-1.17-b-0.16-fedora/hashibox.qcow2
murphy     murphy-srv-01                 Stopped    nomad-consul-quickstart    100         4             4       /Users/ranjan/.shikari/c-1.19-n-1.8-v-1.17-b-0.16-fedora/hashibox.qcow2
```