### PR TITLE
Ignore errors that returns from within the shell

### DIFF
--- a/app/lima/lima.go
+++ b/app/lima/lima.go
@@ -192,10 +192,7 @@ func ShellLimaVM(vmName string) {
 		log.Fatalf("Failed to get a shell inside %s: %v", vmName, err)
 	}
 
-	// Wait for the command to finish and check for errors
-	if err := cmd.Wait(); err != nil {
-		log.Fatalf("Command finished with error: %v", err)
-	}
+	cmd.Wait()
 }
 
 func (vm LimaVM) GetScenarioNameFromEnv() string {


### PR DESCRIPTION
### Existing version

```
❯ shikari version
0.6.0

❯ shikari shell murphy-cli-01
[ranjan@lima-murphy-cli-01 ~]$ 3
bash: 3: command not found

[ranjan@lima-murphy-cli-01 ~]$ 
logout
2024/08/30 09:47:06 Command finished with error: exit status 127
```

### Fixed version

```
❯ go run . shell murphy-cli-01
[ranjan@lima-murphy-cli-01 ~]$ 3
bash: 3: command not found
[ranjan@lima-murphy-cli-01 ~]$ 
logout
```

fixes: #69