### PR TITLE
Add --quiet flag to exec command for clean output

### DIFF
--- a/app/lima/lima.go
+++ b/app/lima/lima.go
@@ -140,9 +140,11 @@ func DeleteLimaVM(vmName string, force bool, wg *sync.WaitGroup, errCh chan<- er
 	fmt.Printf("Lima VM %s deleted successfully.\n", vmName)
 }
 
-func ExecLimaVM(vmName string, command string) {
+func ExecLimaVM(vmName string, command string, quiet bool) {
 
-	fmt.Printf("\nRunning command against: %s\n\n", vmName)
+	if !quiet {
+		fmt.Printf("\nRunning command against: %s\n\n", vmName)
+	}
 
 	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("limactl shell %s %s", vmName, command))
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -21,6 +21,7 @@ var execCmd = &cobra.Command{
 You can run commands against specific class of servers (clients, servers or all)`,
 	Run: func(cmd *cobra.Command, args []string) {
 
+		quiet, _ := cmd.Flags().GetBool("quiet")
 		execAll, _ := cmd.Flags().GetBool("all")
 		execServers, _ := cmd.Flags().GetBool("servers")
 		execClients, _ := cmd.Flags().GetBool("clients")
@@ -41,14 +42,14 @@ You can run commands against specific class of servers (clients, servers or all)
 
 		if execAll {
 			for _, vmName := range instances {
-				lima.ExecLimaVM(vmName.Name, strings.Join(args, " "))
+				lima.ExecLimaVM(vmName.Name, strings.Join(args, " "), quiet)
 			}
 		}
 
 		if execServers {
 			for _, vmName := range instances {
 				if strings.HasPrefix(vmName.Name, fmt.Sprintf("%s-srv", clusterName)) {
-					lima.ExecLimaVM(vmName.Name, strings.Join(args, " "))
+					lima.ExecLimaVM(vmName.Name, strings.Join(args, " "), quiet)
 				}
 
 			}
@@ -57,7 +58,7 @@ You can run commands against specific class of servers (clients, servers or all)
 		if execClients {
 			for _, vmName := range instances {
 				if strings.HasPrefix(vmName.Name, fmt.Sprintf("%s-cli", clusterName)) {
-					lima.ExecLimaVM(vmName.Name, strings.Join(args, " "))
+					lima.ExecLimaVM(vmName.Name, strings.Join(args, " "), quiet)
 				}
 
 			}
@@ -68,7 +69,7 @@ You can run commands against specific class of servers (clients, servers or all)
 			for _, vmName := range instances {
 				if strings.HasSuffix(vmName.Name, execInstance) {
 					instanceExists = true
-					lima.ExecLimaVM(vmName.Name, strings.Join(args, " "))
+					lima.ExecLimaVM(vmName.Name, strings.Join(args, " "), quiet)
 				}
 			}
 			if !instanceExists {
@@ -82,6 +83,7 @@ You can run commands against specific class of servers (clients, servers or all)
 func init() {
 	rootCmd.AddCommand(execCmd)
 
+	execCmd.Flags().BoolP("quiet", "q", false, "prints only the output of the commands without headers")
 	execCmd.Flags().BoolP("clients", "c", false, "run commands against client instances in the cluster")
 	execCmd.Flags().BoolP("servers", "s", false, "run commands against server instances in the cluster")
 	execCmd.Flags().BoolP("all", "a", false, "run commands against all instances in the cluster")


### PR DESCRIPTION
* Without `--quiet`
  ```
  ❯ go run . exec -a -n murphy "systemctl status consul"             
  
  Running command against: murphy-cli-01
  
  ● consul.service - "HashiCorp Consul - A service mesh solution"
       Loaded: loaded (/usr/lib/systemd/system/consul.service; enabled; preset: disabled)
      Drop-In: /usr/lib/systemd/system/service.d
               └─10-timeout-abort.conf
       Active: active (running) since Thu 2024-08-29 11:51:16 UTC; 12h ago
         Docs: https://www.consul.io/
     Main PID: 1401 (consul)
        Tasks: 10 (limit: 4542)
       Memory: 39.8M (peak: 42.0M)
          CPU: 58.561s
       CGroup: /system.slice/consul.service
               └─1401 /usr/bin/consul agent -config-dir=/etc/consul.d/
  
  Running command against: murphy-srv-01
  
  ● consul.service - "HashiCorp Consul - A service mesh solution"
       Loaded: loaded (/usr/lib/systemd/system/consul.service; enabled; preset: disabled)
      Drop-In: /usr/lib/systemd/system/service.d
               └─10-timeout-abort.conf
       Active: active (running) since Thu 2024-08-29 11:50:46 UTC; 12h ago
         Docs: https://www.consul.io/
     Main PID: 1402 (consul)
        Tasks: 11 (limit: 4542)
       Memory: 119.1M (peak: 123.4M)
          CPU: 1min 39.136s
       CGroup: /system.slice/consul.service
               └─1402 /usr/bin/consul agent -config-dir=/etc/consul.d/
  ```

* With `--quiet`
  ```
  ❯ go run . exec -a -n murphy --quiet "systemctl status consul"
  ● consul.service - "HashiCorp Consul - A service mesh solution"
       Loaded: loaded (/usr/lib/systemd/system/consul.service; enabled; preset: disabled)
      Drop-In: /usr/lib/systemd/system/service.d
               └─10-timeout-abort.conf
       Active: active (running) since Thu 2024-08-29 11:51:16 UTC; 12h ago
         Docs: https://www.consul.io/
     Main PID: 1401 (consul)
        Tasks: 10 (limit: 4542)
       Memory: 40.0M (peak: 42.0M)
          CPU: 58.788s
       CGroup: /system.slice/consul.service
               └─1401 /usr/bin/consul agent -config-dir=/etc/consul.d/
  ● consul.service - "HashiCorp Consul - A service mesh solution"
       Loaded: loaded (/usr/lib/systemd/system/consul.service; enabled; preset: disabled)
      Drop-In: /usr/lib/systemd/system/service.d
               └─10-timeout-abort.conf
       Active: active (running) since Thu 2024-08-29 11:50:46 UTC; 12h ago
         Docs: https://www.consul.io/
     Main PID: 1402 (consul)
        Tasks: 11 (limit: 4542)
       Memory: 119.5M (peak: 123.4M)
          CPU: 1min 39.499s
       CGroup: /system.slice/consul.service
               └─1402 /usr/bin/consul agent -config-dir=/etc/consul.d/
  ```

fixes: #71 