### PR TITLE
Remove the restriction on Server node count

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -4,8 +4,6 @@ Copyright © 2024 Ranjandas Athiyanathum Poyil thejranjan@gmail.com
 package cmd
 
 import (
-	"fmt"
-
 	shikari "github.com/ranjandas/shikari/app/shikari"
 	"github.com/spf13/cobra"
 )
@@ -16,12 +14,6 @@ var scaleCmd = &cobra.Command{
 	Short: "Scale the number of VMs in the cluster",
 	Long:  `Scale the number of VMs in the cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-
-		if cluster.NumServers > 5 {
-			fmt.Println("Servers are not recommended to be more than 5!")
-			return
-		}
-
 		cluster.CreateCluster(true)
 	},
 }


### PR DESCRIPTION
Currently, when scaling the cluster, shikari doesn't allow the number of nodes to be greater than 5. This is not required anymore, as it is left to the scenarios on how to handle this gracefully, and shikari shouldn't impose a limitation on number of nodes.

Fixes: #74