### PR TITLE
Introduce arch flag for launching clusters

### DIFF
--- a/app/lima/lima.go
+++ b/app/lima/lima.go
@@ -159,11 +159,11 @@ func ExecLimaVM(vmName string, command string, quiet bool) {
 	}
 }
 
-func SpawnLimaVM(vmName string, tmpl string, yqExpression string, wg *sync.WaitGroup, errCh chan<- error) {
+func SpawnLimaVM(vmName string, arch string, tmpl string, yqExpression string, wg *sync.WaitGroup, errCh chan<- error) {
 	defer wg.Done()
 
 	// Define the command to spawn a Lima VM
-	limaCmd := fmt.Sprintf("limactl start --name %s %s --tty=false --set '%s'", vmName, tmpl, yqExpression)
+	limaCmd := fmt.Sprintf("limactl start --name %s %s --arch %s --tty=false --set '%s'", vmName, tmpl, arch, yqExpression)
 	cmd := exec.Command("/bin/sh", "-c", limaCmd)
 
 	// Set the output to os.Stdout and os.Stderr

--- a/app/lima/types.go
+++ b/app/lima/types.go
@@ -12,6 +12,7 @@ type Image struct {
 
 type LimaVM struct {
 	Name   string `json:"name"`
+	Arch   string `json:"arch"`
 	Status string `json:"status"`
 	Dir    string `json:"dir"`
 	Memory uint64 `json:"memory"`

--- a/app/shikari/shikari.go
+++ b/app/shikari/shikari.go
@@ -134,7 +134,7 @@ func (c ShikariCluster) CreateCluster(scale bool) {
 			wg.Add(1)
 			yqExpr := fmt.Sprintf(`%s | .env.SHIKARI_VM_MODE="%s"`, yqExpression, c.getInstanceMode(vmName))
 
-			go lima.SpawnLimaVM(vmName, tmpl, yqExpr, &wg, errCh)
+			go lima.SpawnLimaVM(vmName, c.Arch, tmpl, yqExpr, &wg, errCh)
 			yqExpr = ""
 
 		}

--- a/app/shikari/types.go
+++ b/app/shikari/types.go
@@ -2,6 +2,7 @@ package shikari
 
 type ShikariCluster struct {
 	Name       string
+	Arch       string
 	NumServers uint8
 	NumClients uint8
 	Template   string

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -38,6 +38,7 @@ func init() {
 	createCmd.Flags().Uint8VarP(&cluster.NumServers, "servers", "s", 1, "number of servers")
 	createCmd.Flags().Uint8VarP(&cluster.NumClients, "clients", "c", 0, "number of clients")
 	createCmd.Flags().StringVarP(&cluster.Name, "name", "n", "", "name of the cluster")
+	createCmd.Flags().StringVarP(&cluster.Arch, "arch", "a", "aarch64", "the architecture of the VM (supported by Lima). Eg: aarch64, s390x")
 	createCmd.Flags().StringVarP(&cluster.Template, "template", "t", "./hashibox.yaml", "name of lima template for the VMs")
 	createCmd.Flags().StringSliceVarP(&cluster.EnvVars, "env", "e", []string{}, "provide environment vars in the for key=value (can be used multiple times)")
 	createCmd.Flags().StringVarP(&cluster.ImgPath, "image", "i", "", "path to the cqow2 images to be used for the VMs, overriding the one in the template")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"runtime"
 	"strings"
 	"text/tabwriter"
 
@@ -40,7 +39,7 @@ func listInstances(clusterName string) {
 	w := tabwriter.NewWriter(os.Stdout, 4, 8, 4, byte(' '), 0)
 
 	if !noheader {
-		fmt.Fprintln(w, "CLUSTER\tVM NAME\tIP(lima0)\tSTATUS\tSCENARIO\tDISK(GB)\tMEMORY(GB)\tCPUS\tIMAGE")
+		fmt.Fprintln(w, "CLUSTER\tVM NAME\tARCH\tIP(lima0)\tSTATUS\tSCENARIO\tDISK(GB)\tMEMORY(GB)\tCPUS\tIMAGE")
 	}
 
 	for _, vm := range vms {
@@ -51,26 +50,25 @@ func listInstances(clusterName string) {
 					continue //skip printing the
 				}
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\n", getClusterNameFromInstanceName(vm.Name), vm.Name, vm.GetIPAddress(), vm.Status, vm.GetScenarioNameFromEnv(), bytesToGiB(vm.Disk), bytesToGiB(vm.Memory), vm.Cpus, getImageLocation(vm.Config.Images))
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\n", getClusterNameFromInstanceName(vm.Name),
+				vm.Name, vm.Arch, vm.GetIPAddress(),
+				vm.Status, vm.GetScenarioNameFromEnv(),
+				bytesToGiB(vm.Disk), bytesToGiB(vm.Memory),
+				vm.Cpus,
+				getImageLocation(vm),
+			)
 		}
 	}
 	w.Flush()
 }
 
-func getImageLocation(images []lima.Image) string {
+func getImageLocation(vm lima.LimaVM) string {
 
-	var arch, location string
+	var location string
 
-	switch runtime.GOARCH {
-	case "arm64":
-		arch = "aarch64"
-	case "amd64":
-		arch = "x86_64"
-	}
+	for _, image := range vm.Config.Images {
 
-	for _, image := range images {
-
-		if image.Arch == arch {
+		if image.Arch == vm.Arch {
 			location = image.Location
 		}
 	}


### PR DESCRIPTION
This PR is the first step towards using the s390x support introduced in Lima 1.1. The following changes were made to support this:

* introduced `--arch` flag. This allows for the setting of the target architecture of the VMs of the cluster, allowing non-native architecture support
* introduced `arch` in the  _list_ output: this makes it easy to identify the VM's architecture type