### PR TITLE
Added missing arch flag to scale subcommand

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -30,6 +30,8 @@ func init() {
 	scaleCmd.Flags().StringSliceVarP(&cluster.EnvVars, "env", "e", []string{}, "provide environment vars in the for key=value (can be used multiple times)")
 	scaleCmd.Flags().StringVarP(&cluster.ImgPath, "image", "i", "", "path to the cqow2 images to be used for the VMs, overriding the one in the template")
 	scaleCmd.Flags().BoolVarP(&cluster.Force, "force", "f", false, "force scaling down of the cluster VMs")
+	scaleCmd.Flags().StringVarP(&cluster.Arch, "arch", "a", "aarch64", "the architecture of the VM (supported by Lima). Eg: aarch64, s390x")
+
 	scaleCmd.MarkFlagRequired("name")
 	scaleCmd.MarkFlagsOneRequired("clients", "servers")
 }


### PR DESCRIPTION
This PR introduces the `--arch` flag, which was missing for the `scale` subcommand. 