### PR TITLE
Feature: Auto-load licenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 dist/
+shikari

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $ shikari create \
     --env NOMAD_LICENSE=$(cat nomad.hclic)
 ```
 
+If available, license environment variables will be automatically configured. See [License Auto-Loading](#license-auto-loading) for more details.
+
 ### List
 
 The `list` command is used to list the clusters and their VMs. You can get VMs of a specific cluster by passing the `--name/-n` flag.
@@ -160,6 +162,14 @@ $ shikari destroy -f -n murphy
 #### List
 
 Lists licenses available for auto-loading and the environment variable they may populate.
+
+## License Auto-Loading
+
+License files (`*.hclic`) found in `~/.shikari` will be read and used to automatically populate license environment variables.
+
+Files should be named for the product they're for, i.e. `~/.shikari/consul.hclic`. This file would be used to populate the `CONSUL_LICENSE` environment variable.
+
+If a license environment variable is specified manually, e.g. `--env CONSUL_LICENSE=$(cat scenario_specific_consul_license.hclic)`, auto-loading will be skipped for that product.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ The following are the pre-requisites for using Shikari
 
 The Shikari binaries are available to download from GH releases. Please download the binary from here: https://github.com/Ranjandas/shikari/releases/latest
 
-
 ## Usage
 
-Shikari can be used to create clusters of any size depending on the capacity of the host on which the VMs are provisioned. Shikari under the hood invokes Lima commands to provision VMs. 
+Shikari can be used to create clusters of any size depending on the capacity of the host on which the VMs are provisioned. Shikari under the hood invokes Lima commands to provision VMs.
 
 The following sub-sections (named after various subcommands) shows how to use Shikari to create, use and destroy clusters.
 
@@ -95,10 +94,9 @@ lima-murphy-srv-01  192.168.105.13:8301  alive   server  1.18.2  2         murph
 lima-murphy-cli-01  192.168.105.10:8301  alive   client  1.18.2  2         murphy  default    <default>
 ```
 
-
 ### Stop
 
-The `stop` command stops all the VMs in a cluster to save resources. 
+The `stop` command stops all the VMs in a cluster to save resources.
 
 ```
 $ shikari stop -n <cluster-name>
@@ -157,6 +155,11 @@ The `destroy` command destroys the cluster as long as all the VMs in the cluster
 $ shikari destroy -f -n murphy
 ```
 
+### License
+
+#### List
+
+Lists licenses available for auto-loading and the environment variable they may populate.
 
 ## Feedback
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -23,6 +23,7 @@ $ shikari create --name murphy --servers 3  --clients 3 --template hashibox --en
 The above command will create a 3 server and 3 client cluster, each vm
 carrying the name as a prefix to easily identify.
 `,
+	PreRunE: loadLicenses,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(lima.GetInstancesByPrefix(cluster.Name)) > 0 {
 			fmt.Printf("Cluster %s alredy exist!", cluster.Name)
@@ -42,6 +43,7 @@ func init() {
 	createCmd.Flags().StringVarP(&cluster.Template, "template", "t", "./hashibox.yaml", "name of lima template for the VMs")
 	createCmd.Flags().StringSliceVarP(&cluster.EnvVars, "env", "e", []string{}, "provide environment vars in the for key=value (can be used multiple times)")
 	createCmd.Flags().StringVarP(&cluster.ImgPath, "image", "i", "", "path to the cqow2 images to be used for the VMs, overriding the one in the template")
+
 	createCmd.MarkFlagRequired("name")
 	createCmd.MarkFlagRequired("servers")
 }

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -19,7 +19,7 @@ var destroyCmd = &cobra.Command{
 	Long: `Destroys VM's that belong to the named cluster
 
 	Exmple:
-	
+
 	$ shikari destroy -n murphy`,
 	Run: func(cmd *cobra.Command, args []string) {
 		//fmt.Println("destroy called")
@@ -54,6 +54,7 @@ func init() {
 
 	destroyCmd.Flags().StringVarP(&cluster.Name, "name", "n", "", "name of the cluster")
 	destroyCmd.Flags().BoolVarP(&cluster.Force, "force", "f", false, "force destruction of the cluster even when VMs are running")
+	destroyCmd.MarkFlagRequired("name")
 }
 
 func destroyVM(instances []lima.LimaVM, force bool) {

--- a/cmd/license.go
+++ b/cmd/license.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -49,5 +51,42 @@ func findLicenses() ([]string, error) {
 func licenseEnvVarKey(path string) string {
 	licenseFilename := filepath.Base(path)
 	licenseName := strings.TrimSuffix(licenseFilename, filepath.Ext(licenseFilename))
-	return strings.ToUpper(licenseName) + "_LICENSE"
+	unsafeName := strings.ToUpper(licenseName)
+	safeName := regexp.MustCompile(`[^A-Za-z0-9_]`).ReplaceAllString(unsafeName, "_")
+	return safeName + "_LICENSE"
+}
+
+func loadLicenses(cmd *cobra.Command, args []string) error {
+	licenses, err := findLicenses()
+	if err != nil {
+		return err
+	}
+
+	for _, license := range licenses {
+		if err = loadLicense(license); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func loadLicense(path string) error {
+	envVarKey := licenseEnvVarKey(path)
+
+	if !slices.ContainsFunc(cluster.EnvVars, func(v string) bool {
+		return strings.HasPrefix(v, envVarKey)
+	}) {
+		if _, err := os.Stat(path); err != nil {
+			return err
+		}
+
+		license, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		cluster.EnvVars = append(cluster.EnvVars, envVarKey+"="+strings.TrimSpace(string(license)))
+	}
+	return nil
 }

--- a/cmd/license.go
+++ b/cmd/license.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var licenseCmd = &cobra.Command{
+	Use:   "license",
+	Short: "Manage automatically loadable licenses",
+}
+
+var licenseListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the licenses that will be auto-loaded",
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		licenses, err := findLicenses()
+		if err != nil {
+			return err
+		}
+
+		for _, l := range licenses {
+			fmt.Printf("%s will be loaded as default value for environment variable %s\n", l, licenseEnvVarKey(l))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(licenseCmd)
+	licenseCmd.AddCommand(licenseListCmd)
+}
+
+func findLicenses() ([]string, error) {
+	homePath, err := os.UserHomeDir()
+	if err != nil {
+		return []string{}, err
+	}
+
+	return filepath.Glob(filepath.Join(homePath, ".shikari", "*.hclic"))
+}
+
+func licenseEnvVarKey(path string) string {
+	licenseFilename := filepath.Base(path)
+	licenseName := strings.TrimSuffix(licenseFilename, filepath.Ext(licenseFilename))
+	return strings.ToUpper(licenseName) + "_LICENSE"
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,8 +18,11 @@ package cmd
 import (
 	"os"
 
+	"github.com/ranjandas/shikari/app/shikari"
 	"github.com/spf13/cobra"
 )
+
+var cluster shikari.ShikariCluster
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -4,21 +4,19 @@ Copyright © 2024 Ranjandas Athiyanathum Poyil thejranjan@gmail.com
 package cmd
 
 import (
-	shikari "github.com/ranjandas/shikari/app/shikari"
 	"github.com/spf13/cobra"
 )
 
 // scaleCmd represents the scale command
 var scaleCmd = &cobra.Command{
-	Use:   "scale",
-	Short: "Scale the number of VMs in the cluster",
-	Long:  `Scale the number of VMs in the cluster`,
+	Use:     "scale",
+	Short:   "Scale the number of VMs in the cluster",
+	Long:    `Scale the number of VMs in the cluster`,
+	PreRunE: loadLicenses,
 	Run: func(cmd *cobra.Command, args []string) {
 		cluster.CreateCluster(true)
 	},
 }
-
-var cluster shikari.ShikariCluster
 
 func init() {
 	rootCmd.AddCommand(scaleCmd)


### PR DESCRIPTION
Automatically populates license environment variables for `.hclic` files found in `~/.shikari`.

```
$ shikari license list
/home/path/.shikari/consul.hclic will be loaded as default value for environment variable CONSUL_LICENSE
/home/path/.shikari/nomad.hclic will be loaded as default value for environment variable NOMAD_LICENSE
```

If a license environment variable is specified, automatic loading for that product is skipped.